### PR TITLE
Make background transparent instead of green

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -8,7 +8,7 @@ body {
     flex-direction: column;
     place-content: center;
     place-items: center;
-    background-color: rgb(0,255,0);
+    background-color: rgba(0,0,0,0);
     height: 100vh;
     margin: 0px;
     padding: 0px;

--- a/public/style.css
+++ b/public/style.css
@@ -12,6 +12,7 @@ body {
     height: 100vh;
     margin: 0px;
     padding: 0px;
+    color: rgb(127, 127, 127);
 }
 h1 {
     font-family: "cubanoregular";


### PR DESCRIPTION
This changes the body's background colour to rgba(0, 0, 0, 0), which makes it transparent, without you needing to apply the chroma key filter and removing all the bright greens!
If you're using the OBS Browser source, that is, unlike Dan is in his video call meeting annotations tutorial.
Note: you  might want to change the text colour, but that is a thing with browsers doing things differently and what you're trying to overlay it on