### PR TITLE
Added universal toggles for font and colors

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -3,7 +3,14 @@
     src: url("https://thecodingtrain.com/assets/fonts/cubano-regular-webfont.woff2");
 }
 
-html, body {
+:root {
+    --codingtrain-fontface: "cubanoregular";
+    --gradient: linear-gradient(90deg, red, yellow, green, blue, violet);
+    --no-gradient: black;
+}
+
+html,
+body {
     width: 100%;
     margin: 0;
     padding: 0;
@@ -12,34 +19,57 @@ html, body {
 
 body {
     font-family: "Open Sans";
-    width: calc(100% - 20px);
+    width: calc(100% - 40px);
     margin: 10px;
 }
 
-h1::before {content: "🚂 ";}
-h1::after {content: " 🌈";}
-
-h1, button, #total-votes, .question {
-    font-family: 'cubanoregular';
+h1::before {
+    content: "🚂 ";
 }
 
-#results {width: calc(100% - 20px);}
+h1::after {
+    content: " 🌈";
+}
+
+h1,
+button,
+#total-votes,
+.question {
+    font-family: var(--codingtrain-fontface);
+}
+
+#results {
+    width: calc(100% - 20px);
+}
 
 .progressBar {
     margin: 0 5px 5px 0;
-    padding: 0 10px;
-    background: linear-gradient(90deg, red,  yellow, green, blue,  violet);
-    /* background: linear-gradient(90deg, red, orange, yellow, green, blue, indigo, violet); */
+    padding: 5px 20px;
     color: white;
+    background: black;
     transition: width 1s;
-    font-family: 'cubanoregular';
+    font-family: var(--codingtrain-fontface);
+    font-size: larger;
     border-radius: 100px;
+
+}
+
+.gradient {
+    background: linear-gradient(90deg, red, yellow, green, blue, violet);
 }
 
 main {
     width: min-content;
 }
 
-textarea, input {
+textarea,
+input {
     font-family: inherit;
+}
+
+
+#footer {
+    position: fixed;
+    bottom: 30px;
+
 }

--- a/views/create.pug
+++ b/views/create.pug
@@ -7,3 +7,4 @@ html
   body
     h1 Create poll
     script(src="/js/sketches/create.js")
+    include footer.pug

--- a/views/footer.pug
+++ b/views/footer.pug
@@ -1,0 +1,56 @@
+div(id="footer")
+  h3 View options
+  div
+    input(type="checkbox" id="font-toggle")
+    label(for="font-toggle") Use simplier font
+  div
+    input(type="checkbox" id="gradient-toggle")
+    label(for="gradient-toggle") Disable gradients
+
+  script.
+
+    // checkboxes
+    let fontToggle = document.querySelector('#font-toggle');
+    let gradientToggle = document.querySelector('#gradient-toggle');
+
+    // initial state from localStorage
+    fontToggle.checked = localStorage.getItem('font-simple') == 'true';
+    gradientToggle.checked = localStorage.getItem('no-gradient') == 'true';
+    changeGradient(gradientToggle.checked);
+    changeFonts(fontToggle.checked);
+
+
+    // input handlers
+    fontToggle.oninput = function() {
+      localStorage.setItem('font-simple', fontToggle.checked);
+      changeFonts(fontToggle.checked);
+    };
+
+    gradientToggle.oninput = function() {
+      localStorage.setItem('no-gradient', gradientToggle.checked);
+      changeGradient(gradientToggle.checked);
+    };
+
+    // toggle font by switching the variable in css
+    function changeFonts(simple) {
+      if (simple)
+      document.documentElement.style.setProperty('--codingtrain-fontface', 'Open Sans');
+      else
+      document.documentElement.style.setProperty('--codingtrain-fontface', 'cubanoregular');
+    }
+
+
+    // remove gradient by removing or adding the correct class to the progress bar
+    function changeGradient(off) {
+      if (off)  {
+        let elements = document.getElementsByClassName('progressBar');
+        for (let element of elements) {
+          element.classList.remove('gradient')
+        }
+      } else {
+        let elements = document.getElementsByClassName('progressBar');
+        for (let element of elements) {
+          element.classList.add('gradient')
+        }
+      }
+    }

--- a/views/index.pug
+++ b/views/index.pug
@@ -18,3 +18,5 @@ html
     else
       p No Polls Found!
       a(href="/create") Create One Here
+    include footer.pug
+

--- a/views/poll.pug
+++ b/views/poll.pug
@@ -9,8 +9,9 @@ html
     div#results
       each val, index in poll.options
         div.option
-          div=val
+          div= val
           div(id="progressBar_" + index class="progressBar")
     p#totalVotes
     script(src="/js/classes/poll.js")
     script(src="/js/sketches/poll.js")
+    include footer.pug

--- a/views/vote.pug
+++ b/views/vote.pug
@@ -16,3 +16,4 @@ html
       input(type="submit" value="Vote")
     script(src="/js/classes/poll.js")
     script(src="/js/sketches/vote.js")
+    include footer.pug


### PR DESCRIPTION
I know there were concerns raised over the rainbow gradient in the results page and I wasn't really sure what the best way to go about fixing it would be but I added the ability to turn on and off the gradient effect from any page. It will also remember your choice using `localStorage` so you don't have to continuously toggle it. 

The bottom of every page has a `include footer.pug` which is where the controls and code that makes them work is stored. You could remove this from any page where you did not want the controls to appear. I suppose you could also hide it until it is requested by the user but I didn't add that. 

In addition, you can change what the gradient for the voting bar looks like by editing the `.gradient` class in `styles.css`. The progress bars by default now just have a black background. Editing the `background` property in the `.progressBar` class would allow you to change that. 

I also found the rainbow bars cute but kind of hard to look at. I realize this might not be an ideal solution that won't get merged in but I felt like I wanted to contribute anyway 😁. 

There is one more change which lets you change the Cubano font to Open Sans because even though it is the Coding Train font, it was hard to read especially on small screens. 