### PR TITLE
New options for view control

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6,7 +6,9 @@
 :root {
     --codingtrain-fontface: "cubanoregular";
     --gradient: linear-gradient(90deg, red, yellow, green, blue, violet);
+    --monochrome-gradient: repeating-linear-gradient(60deg, #A42963, #A42963 10px, #F063A4 10px, #F063A4 20px);
     --no-gradient: black;
+    --progressbar-color: white;
 }
 
 html,
@@ -45,8 +47,9 @@ button,
 .progressBar {
     margin: 0 5px 5px 0;
     padding: 5px 20px;
-    color: white;
-    background: black;
+    color: var(--progressbar-color);
+    /* background: repeating-linear-gradient(30deg, #A42963 10px, #F063A4 30px); */
+    background: var(--monochrome-gradient);
     transition: width 1s;
     font-family: var(--codingtrain-fontface);
     font-size: larger;
@@ -67,21 +70,19 @@ textarea,
 input {
     font-family: inherit;
 }
-#footer {
-    position: fixed;
-    bottom: 30px;
 
-}
 
 div#views {
     position: absolute;
     bottom: 0px;
-    width:98%;
+    width: 98%;
 }
 
-div#views ul{
-    list-style: none;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly;
+
+div#views ul {
+    list-style-type: none;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(min-content, 1fr));
+    justify-items: center;
+
 }

--- a/public/js/sketches/poll.js
+++ b/public/js/sketches/poll.js
@@ -20,13 +20,44 @@ async function setup() {
         document.querySelectorAll("div.progressBar").forEach(p => {
           p.style.background = "purple";
         });
-      } break;
-      case "overlay": {
-        //set the background to semi-transperant white
-        document.body.style.background = "rgba(255,255,255,50%)"
-        //remove view links in overlay view
-        document.querySelector("div#views").remove();
-      } break;
+      }
+      break;
+    case "overlay": {
+      //set the background to semi-transperant white
+      document.body.style.background = "rgba(255,255,255,50%)"
+      //remove view links in overlay view
+      document.querySelector("div#views").remove();
     }
+    break;
+    }
+  }
+
+
+  // from https://github.com/CodingTrain/LateNight/issues/1
+  const colorPairs = [
+    ['#9253a1', '#70327e'],
+    ['#f063a4', '#ec015a'],
+    ['#2dc5f4', '#0b6a88'],
+    ['#fcee21', '#f89e4f'],
+    ['#f16164', '#ec015a'],
+    ['#70327e', '#9253a1'],
+    ['#a42963', '#ec015a'],
+    ['#0b6a88', '#2dc5f4'],
+    ['#f89e4f', '#fcee21'],
+    ['#ec015a', '#a42963'],
+  ];
+
+  const [first, second] = random(colorPairs);
+  const degrees = random(35, 75) * (random() < 0.5 ? -1 : 1);
+
+  const gradient = `repeating-linear-gradient(${nf(degrees, 0, 1)}deg, ${first}, ${first} 10px, ${second} 10px, ${second} 20px`;
+
+  const root = document.documentElement;
+  root.style.setProperty('--monochrome-gradient', gradient);
+
+  console.log(green(color(first)))
+  console.log(green(color(second)))
+  if (green(color(first)) > 127 && green(color(second)) > 127) {
+    root.style.setProperty('--progressbar-color', 'black');
   }
 }

--- a/views/footer.pug
+++ b/views/footer.pug
@@ -1,6 +1,8 @@
 div#views
   hr
-  h3 View options
+  h3 View options &nbsp;
+    a(style="font-size: 0.7em" onclick="this.parentNode.parentNode.remove()")
+      i [close]
   ul
     li
       input(type="checkbox" id="font-toggle")

--- a/views/footer.pug
+++ b/views/footer.pug
@@ -1,17 +1,26 @@
-div(id="footer")
+div#views
+  hr
   h3 View options
-  div
-    input(type="checkbox" id="font-toggle")
-    label(for="font-toggle") Use simplier font
-  div
-    input(type="checkbox" id="gradient-toggle")
-    label(for="gradient-toggle") Disable gradients
+  ul
+    li
+      input(type="checkbox" id="font-toggle")
+      label(for="font-toggle") Use simplier font
+    li
+      input(type="checkbox" id="gradient-toggle")
+      label(for="gradient-toggle") Disable gradients
+    li
+      input(type="checkbox" id="overlay-toggle")
+      label(for="overlay-toggle") Overlay View
 
   script.
 
     // checkboxes
     let fontToggle = document.querySelector('#font-toggle');
     let gradientToggle = document.querySelector('#gradient-toggle');
+
+    // do not cache so because controls are removed when activating
+    // refresh page to bring back controls
+    let overlayToggle = document.querySelector('#overlay-toggle');
 
     // initial state from localStorage
     fontToggle.checked = localStorage.getItem('font-simple') == 'true';
@@ -29,6 +38,10 @@ div(id="footer")
     gradientToggle.oninput = function() {
       localStorage.setItem('no-gradient', gradientToggle.checked);
       changeGradient(gradientToggle.checked);
+    };
+
+    overlayToggle.oninput = function() {
+      changeView(overlayToggle.checked);
     };
 
     // toggle font by switching the variable in css
@@ -52,5 +65,17 @@ div(id="footer")
         for (let element of elements) {
           element.classList.add('gradient')
         }
+      }
+    }
+
+    function changeView(overlay) {
+      if (overlay) {
+        //set the background to semi-transperant white
+        document.body.style.background = "rgba(255,255,255,50%)"
+        //remove view links in overlay view
+        document.querySelector("div#views").remove();
+      } else {
+        //set the background to white white
+        document.body.style.background = "rgba(255,255,255)"
       }
     }

--- a/views/poll.pug
+++ b/views/poll.pug
@@ -13,15 +13,7 @@ html
           div= val
           div(id="progressBar_" + index class="progressBar")
     p#totalVotes
-    div#views
-      hr
-      ul
-        li
-          a(href="?") normal view
-        li
-          a(href="?view=overlay") overlay view
-        li
-          a(href="?view=nogradient") no gradient view
-    script(src="/js/classes/poll.js")
-    script(src="/js/sketches/poll.js")
-    include footer.pug
+
+      script(src="/js/classes/poll.js")
+      script(src="/js/sketches/poll.js")
+      include footer.pug


### PR DESCRIPTION
Hi, I hope I'm not being annoying make many pull requests and changes 😓 but I changed a couple of things from the last time. 

First I noticed new options for changing to overlay were on top of my options for views, so I consolidated them 

I added a close button so that you can dismiss the view options if they are in the way. 

I changed the way the "no gradient" option looks so it has color instead of just being black, but I hope it will be easier to see. Colors come from [Coding Train Colors](https://coding-train-colors.now.sh). 

Since the "overlay" view option also deleted the element that contained the links to other options, I removed all the options except "overlay view". My reasoning is that once the links disappear you still have to refresh the page to get the normal view back so the extra links didn't seem to help. 

The only thing missing is the completely monochrome, single color progress bar option which was removed when I consolidated all the code. I didn't want to keep adding to this and have a gigantic pull request, but I would be happy to add back that functionality if you like the rest of what I did and still want it.

I enjoy working on this project for fun and I hope I am not causing trouble. Feel free to ignore this very long PR if its too much or not what you're looking for. Thank you 🚂 🌈 