### PR TITLE
Authentication on /api/new route

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -1,4 +1,5 @@
 const database = require("./helpers/database");
+const basicauth = require("./validation/basicauth");
 const createNewPoll = require("./helpers/createNewPoll");
 const express = require("express");
 const router = express.Router();
@@ -9,6 +10,14 @@ router.post("/new", async (request, response) => {
   //   question: string,
   //   options:  string[]
   // }
+  if (!basicauth.isAuthenticated(request, response)) {
+    response.send({
+      status: 'error',
+      message: 'Not authenticated',
+      id: pollID
+    });
+    return;
+  }
 
   let { question, options } = request.body;
 

--- a/server/api.js
+++ b/server/api.js
@@ -14,7 +14,6 @@ router.post("/new", async (request, response) => {
     response.send({
       status: 'error',
       message: 'Not authenticated',
-      id: pollID
     });
     return;
   }


### PR DESCRIPTION
Even though there is authentication on the `/index` and `/create` routes, the actual route that creates the poll `/api/new` has no authentication check. It is therefore possible to issue a post request to `/api/new` and create a poll without being authenticated. I added the import and the simple basicauth check to the route to prevent this.