### PR TITLE
Fixed a method error in poll.js

### DIFF
--- a/public/js/sketches/poll.js
+++ b/public/js/sketches/poll.js
@@ -4,7 +4,7 @@
 async function setup() {
   noCanvas();
   poll = new Poll();
-  poll.startPollingForVotes();
+  poll.initPoll();
 
   // from https://github.com/CodingTrain/LateNight/issues/1
   const colorPairs = [


### PR DESCRIPTION
When viewing the results page, an error occurs because `poll.startPollingForVotes()` no longer exists. Using the `poll.initPoll()` method will fix this.